### PR TITLE
Fix LSPs using `on_new_config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ EOF
 
 `lazy-lsp` registers all available configurations from lspconfig to start LSP servers by wrapping the commands in a [nix-shell](https://nixos.org/manual/nix/unstable/command-ref/nix-shell.html) environment. The nix-shell prepares the environment by pulling all specified dependencies regardless of what is installed on the host system and avoids packages clashes. The first time a server is run there is a delay until dependencies are downloaded, but on subsequent runs the time to prepare the shell environment is negligeable.
 
+If you want to use an LSP that is not already available with this plugin, you can search if this is packaged on nix and use it by defining the "nix_pkg" field on the server configuration.
+Here is an example with lua's lsp:
+
+```lua
+require("lazy-lsp").setup({
+  configs = {
+    lua_ls = {
+      nix_pkg = "lua-language-server",
+    }
+  }
+})
+```
+
 ## Comparison with alternatives
 
 - Installing manually, or via language specific package managers like npm, pip, etc. is a hassle.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ require('lazy-lsp').setup {
     -- on_attach = on_attach,
     -- capabilities = capabilities,
   },
+  -- Define common configurations for all server (optional)
+  common_config = {
+    -- on_attach = on_attach,
+    -- capabilities = capabilities,
+  }
   -- Override config for specific servers that will passed down to lspconfig setup.
   configs = {
     sumneko_lua = {

--- a/lua/lazy-lsp.lua
+++ b/lua/lazy-lsp.lua
@@ -39,6 +39,23 @@ local function setup(opts)
         table.insert(nix_cmd, "--run")
         table.insert(nix_cmd, escape_shell_args(cmd))
         config = vim.tbl_extend("keep", { cmd = nix_cmd }, config)
+
+        -- This method can alter the cmd line, if it does, we merge the new arguments with the binary (since nix-shell does not support --)
+        config.on_new_config = function(new_config, root_path)
+          local fake_config = vim.tbl_extend("keep", { cmd = {} }, new_config)
+          print(vim.inspect(fake_config))
+          pcall(lspconfig[lsp].document_config.default_config.on_new_config, fake_config, root_path)
+
+          if #fake_config.cmd ~= 0 then
+            print(vim.inspect(fake_config.cmd), #fake_config.cmd)
+            local nargs = escape_shell_args{ unpack(cmd), unpack(fake_config.cmd)}
+            print(nargs)
+            print(vim.inspect(new_config.cmd))
+            new_config.cmd[#new_config.cmd] = nargs
+            print(vim.inspect(new_config.cmd))
+          end
+        end
+
         lspconfig[lsp].setup(config)
       elseif configs[lsp] then
         local config = vim.tbl_extend("keep", configs[lsp], common_config)

--- a/lua/lazy-lsp.lua
+++ b/lua/lazy-lsp.lua
@@ -19,8 +19,14 @@ local function setup(opts)
   local default_config = opts.default_config or {}
   local configs = opts.configs or {}
 
-  for lsp, nix_pkg in pairs(servers) do
+  for lsp, npkg in pairs(servers) do
     if lspconfig[lsp] and not vim.tbl_contains(excluded_servers, lsp) then
+      -- Allow users to override nix_pkg (to quickly support new servers)
+      local nix_pkg = (configs[lsp] and configs[lsp].nix_pkg) or npkg
+      if configs[lsp] then
+        configs[lsp].nix_pkg = nil
+      end
+
       local cmd = (configs[lsp] and configs[lsp].cmd) or
           (type(nix_pkg) == "table" and nix_pkg.cmd) or
           lspconfig[lsp].document_config.default_config.cmd

--- a/lua/lazy-lsp.lua
+++ b/lua/lazy-lsp.lua
@@ -43,16 +43,11 @@ local function setup(opts)
         -- This method can alter the cmd line, if it does, we merge the new arguments with the binary (since nix-shell does not support --)
         config.on_new_config = function(new_config, root_path)
           local fake_config = vim.tbl_extend("keep", { cmd = {} }, new_config)
-          print(vim.inspect(fake_config))
           pcall(lspconfig[lsp].document_config.default_config.on_new_config, fake_config, root_path)
 
           if #fake_config.cmd ~= 0 then
-            print(vim.inspect(fake_config.cmd), #fake_config.cmd)
             local nargs = escape_shell_args{ unpack(cmd), unpack(fake_config.cmd)}
-            print(nargs)
-            print(vim.inspect(new_config.cmd))
             new_config.cmd[#new_config.cmd] = nargs
-            print(vim.inspect(new_config.cmd))
           end
         end
 

--- a/lua/lazy-lsp.lua
+++ b/lua/lazy-lsp.lua
@@ -17,6 +17,7 @@ local function setup(opts)
   opts = opts or {}
   local excluded_servers = opts.excluded_servers or {}
   local default_config = opts.default_config or {}
+  local common_config = opts.common_config or {}
   local configs = opts.configs or {}
 
   for lsp, npkg in pairs(servers) do
@@ -31,7 +32,7 @@ local function setup(opts)
           (type(nix_pkg) == "table" and nix_pkg.cmd) or
           lspconfig[lsp].document_config.default_config.cmd
       if nix_pkg ~= "" and cmd then
-        local config = configs[lsp] or default_config
+        local config = vim.tbl_extend("keep", configs[lsp] or default_config, common_config)
         local nix_pkgs = type(nix_pkg) == "string" and { nix_pkg } or nix_pkg.pkgs
         local nix_cmd = { "nix-shell", "-p" }
         vim.list_extend(nix_cmd, nix_pkgs)
@@ -40,7 +41,8 @@ local function setup(opts)
         config = vim.tbl_extend("keep", { cmd = nix_cmd }, config)
         lspconfig[lsp].setup(config)
       elseif configs[lsp] then
-        lspconfig[lsp].setup(configs[lsp])
+        local config = vim.tbl_extend("keep", configs[lsp], common_config)
+        lspconfig[lsp].setup(config)
       end
     end
   end

--- a/lua/lazy-lsp/servers.lua
+++ b/lua/lazy-lsp/servers.lua
@@ -125,7 +125,10 @@ return {
   ocamlls = "nodePackages.ocaml-language-server",
   ocamllsp = "ocamlPackages.ocaml-lsp",
   ols = "",
-  omnisharp = "omnisharp-roslyn",
+  omnisharp = {
+    cmd = { "OmniSharp" },
+    pkgs = { "omnisharp-roslyn", "dotnet-sdk" },
+  },
   opencl_ls = "",
   openscad_ls = "",
   openscad_lsp = "",

--- a/lua/lazy-lsp/servers.lua
+++ b/lua/lazy-lsp/servers.lua
@@ -140,7 +140,7 @@ return {
   phpactor = "",
   please = "",
   powershell_es = "",
-  prismals = "",
+  prismals = 'nodePackages.\"@prisma/language-server\"',
   prolog_ls = "",
   prosemd_lsp = "",
   psalm = "php80Packages.psalm",


### PR DESCRIPTION
This PR includes a few things:
 - Allow custom `nix_pkg` override via the config (when you want to quickly set up a new LSP without directly forking lazy-lsp). 
 - Create a `common_config` to configure fields that are similar on each server (I was tired of forgetting to put `capacities` and `on_attach` every time I added a custom config for a server).
 - Fix LSPs that depends on the `on_new_config` to mutate the command line (this was the case of omnisharp, for example)
 - Fix omnisharp's dependencies / cmd
 - Add prisma to the list of supported LSPs.
 
PS: I could not run the script to update stats, I got the error  `module 'serpent' not found:No LuaRocks module found for serpe
nt`