### PR TITLE
update lua-language-server package name

### DIFF
--- a/lua/lazy-lsp/servers.lua
+++ b/lua/lazy-lsp/servers.lua
@@ -104,7 +104,7 @@ return {
   lelwel_ls = "",
   lemminx = "",
   ltex = "ltex-ls",
-  lua_ls = "lua-language-server",
+  lua_ls = "sumneko-lua-language-server",
   luau_lsp = "",
   m68k = "",
   marksman = "",


### PR DESCRIPTION
Fix for error in Lua LSP package name mentioned in #13. 