### PR TITLE
Add preferred_servers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,21 @@ Alternatively, you can install the plugin via [Nix/Home Manager](./notes.md#inst
 Add to `init.lua`:
 
 ```lua
-require('lazy-lsp').setup {
+require("lazy-lsp").setup {}
+```
+
+Available options:
+
+```lua
+require("lazy-lsp").setup {
   -- By default all available servers are set up. Exclude unwanted or misbehaving servers.
   excluded_servers = {
     "ccls", "zk",
+  },
+  -- Alternatively specify preferred servers for a filetype (others will be ignored).
+  preferred_servers = {
+    haskell = { "hls" },
+    rust = { "rust_analyzer" },
   },
   -- Default config passed to all servers to specify on_attach callback and other options.
   default_config = {
@@ -59,7 +70,7 @@ require('lazy-lsp').setup {
 For `init.vim` based config wrap with lua command:
 ```vim
 lua << EOF
-require('lazy-lsp').setup {
+require("lazy-lsp").setup {
   ...
 }
 EOF

--- a/lua/lazy-lsp/helpers.lua
+++ b/lua/lazy-lsp/helpers.lua
@@ -11,18 +11,23 @@ local function escape_shell_args(args)
 end
 
 -- should rename to something indicating that it is for an individual config
-local function process_config(lang_config, user_config, default_config, nix_pkg)
+local function process_config(lang_config, user_config, default_config, nix_pkg, filetypes)
   local cmd = (user_config and user_config.cmd)
     or (type(nix_pkg) == "table" and nix_pkg.cmd)
     or lang_config.document_config.default_config.cmd
   if nix_pkg ~= "" and cmd then
-    local config = vim.tbl_extend("keep", user_config or {}, default_config)
     local nix_pkgs = type(nix_pkg) == "string" and { nix_pkg } or nix_pkg.pkgs
     local nix_cmd = { "nix-shell", "-p" }
     vim.list_extend(nix_cmd, nix_pkgs)
     table.insert(nix_cmd, "--run")
     table.insert(nix_cmd, escape_shell_args(cmd))
-    config = vim.tbl_extend("keep", { cmd = nix_cmd }, config)
+    local config = vim.tbl_extend(
+      "keep",
+      { cmd = nix_cmd },
+      user_config or {},
+      { filetypes = filetypes },
+      default_config
+    )
 
     -- This method can alter the cmd line, if it does, we merge the new arguments with the binary (since nix-shell does not support --)
     config.on_new_config = function(new_config, root_path)
@@ -44,34 +49,82 @@ local function process_config(lang_config, user_config, default_config, nix_pkg)
   return nil
 end
 
+local function build_filetype_to_servers_index(servers, lspconfig)
+  local index = {}
+  for server, _ in pairs(servers) do
+    if lspconfig[server] then
+      local filetypes = lspconfig[server].document_config.default_config.filetypes
+      if filetypes then
+        for _, filetype in ipairs(filetypes) do
+          if not index[filetype] then
+            index[filetype] = {}
+          end
+          table.insert(index[filetype], server)
+        end
+      else
+        -- what would be a good way to log this?
+        -- print("no filetypes for", server)
+      end
+    end
+  end
+  return index
+end
+
+local function build_server_to_filetypes_index(server_to_filetypes)
+  local index = {}
+  for filetype, servers in pairs(server_to_filetypes) do
+    for _, server in ipairs(servers) do
+      if not index[server] then
+        index[server] = {}
+      end
+      table.insert(index[server], filetype)
+    end
+  end
+  return index
+end
+
 local function server_configs(lspconfig, servers, opts)
   opts = opts or {}
   local excluded_servers = opts.excluded_servers or {}
   local default_config = opts.default_config or {}
   local configs = opts.configs or {}
+  local preferred_servers = opts.preferred_servers or {}
+
+  local included_servers = vim.tbl_extend("force", {}, servers)
+  for _, server in ipairs(excluded_servers) do
+    included_servers[server] = nil
+  end
+
+  local filetype_to_servers = build_filetype_to_servers_index(included_servers, lspconfig)
+  for filetype, filetype_servers in pairs(preferred_servers) do
+    filetype_servers = type(filetype_servers) == "string" and { filetype_servers } or filetype_servers
+    filetype_to_servers[filetype] = filetype_servers
+  end
+  local server_to_filetypes = build_server_to_filetypes_index(filetype_to_servers)
 
   local returned_configs = {}
-
-  for lsp, nix_pkg in pairs(servers) do
+  for lsp, nix_pkg in pairs(included_servers) do
     -- Check if a server is excluded first, so that we don't look up the config
     -- and for deprecated servers we won't get a warning message.
-    if not vim.tbl_contains(excluded_servers, lsp) and lspconfig[lsp] then
+    if server_to_filetypes[lsp] and lspconfig[lsp] then
       local lang_config = lspconfig[lsp]
       local user_config = configs[lsp]
 
-      local config = process_config(lang_config, user_config, default_config, nix_pkg)
+      local config = process_config(lang_config, user_config, default_config, nix_pkg, server_to_filetypes[lsp])
       if config then
         returned_configs[lsp] = config
       end
     end
   end
-
   return returned_configs
 end
 
 return {
+  server_configs = server_configs,
+  -- Internal, only for testing
   escape_shell_arg = escape_shell_arg,
   escape_shell_args = escape_shell_args,
   process_config = process_config,
-  server_configs = server_configs,
+  build_filetype_to_servers_index = build_filetype_to_servers_index,
+  build_server_to_filetypes_index = build_server_to_filetypes_index,
 }

--- a/tests/helpers_spec.lua
+++ b/tests/helpers_spec.lua
@@ -163,3 +163,129 @@ describe("lazy-lsp", function()
     end)
   end)
 end)
+
+local fake_lspconfig = {
+  fakelsp = {
+    document_config = {
+      default_config = { filetypes = { "javascript", "python", "typescript" }, cmd = { "fakelsp-binary" } },
+    },
+  },
+  pylsp = { document_config = { default_config = { filetypes = { "python" }, cmd = { "pylsp" } } } },
+  pyright = {
+    document_config = { default_config = { filetypes = { "python" }, cmd = { "pyright-langserver", "--stdio" } } },
+  },
+  tsserver = {
+    document_config = {
+      default_config = { filetypes = { "javascript", "typescript" }, cmd = { "typescript-language-server", "--stdio" } },
+    },
+  },
+}
+
+local fake_servers = {
+  pylsp = "python39Packages.python-lsp-server",
+  pyright = "pyright",
+  fakelsp = "fakelsp-package",
+  tsserver = {
+    pkgs = {
+      "nodePackages.typescript-language-server",
+      "nodePackages.typescript",
+    },
+  },
+}
+
+local function normalize_table_values(tbl)
+  for _, v in pairs(tbl) do
+    table.sort(v)
+  end
+  return tbl
+end
+
+it("build_filetype_to_servers_index", function()
+  local filetype_to_servers = helpers.build_filetype_to_servers_index(fake_lspconfig, fake_lspconfig)
+
+  assert.same({
+    javascript = { "fakelsp", "tsserver" },
+    python = { "fakelsp", "pylsp", "pyright" },
+    typescript = { "fakelsp", "tsserver" },
+  }, normalize_table_values(filetype_to_servers))
+end)
+
+it("build_server_to_filetypes_index", function()
+  local filetype_to_servers = helpers.build_filetype_to_servers_index(fake_lspconfig, fake_lspconfig)
+  local server_to_filetypes = helpers.build_server_to_filetypes_index(filetype_to_servers)
+
+  assert.same({
+    fakelsp = { "javascript", "python", "typescript" },
+    pylsp = { "python" },
+    pyright = { "python" },
+    tsserver = { "javascript", "typescript" },
+  }, normalize_table_values(server_to_filetypes))
+end)
+
+it("build_server_to_filetypes_index", function()
+  local filetype_to_servers = helpers.build_filetype_to_servers_index(fake_lspconfig, fake_lspconfig)
+  filetype_to_servers.python = { "pyright" }
+  filetype_to_servers.typescript = { "tsserver" }
+  local server_to_filetypes = helpers.build_server_to_filetypes_index(filetype_to_servers)
+
+  assert.same({
+    fakelsp = { "javascript" },
+    pyright = { "python" },
+    tsserver = { "javascript", "typescript" },
+  }, normalize_table_values(server_to_filetypes))
+end)
+
+describe("server_configs", function()
+  it("augments commands with nix-shell", function()
+    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, {})
+    assert.same({ "nix-shell", "-p", "fakelsp-package", "--run", "'fakelsp-binary'" }, cfg.fakelsp.cmd)
+    assert.same({ "nix-shell", "-p", "python39Packages.python-lsp-server", "--run", "'pylsp'" }, cfg.pylsp.cmd)
+    assert.same({ "nix-shell", "-p", "pyright", "--run", "'pyright-langserver' '--stdio'" }, cfg.pyright.cmd)
+    assert.same({
+      "nix-shell",
+      "-p",
+      "nodePackages.typescript-language-server",
+      "nodePackages.typescript",
+      "--run",
+      "'typescript-language-server' '--stdio'",
+    }, cfg.tsserver.cmd)
+  end)
+
+  it("removes excluded servers", function()
+    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, {
+      excluded_servers = { "pylsp", "pyright", "tsserver" },
+    })
+    assert.same({ "nix-shell", "-p", "fakelsp-package", "--run", "'fakelsp-binary'" }, cfg.fakelsp.cmd)
+    assert.is_nil(cfg.pylsp)
+    assert.is_nil(cfg.pyright)
+    assert.is_nil(cfg.tsserver)
+  end)
+
+  it("uses default filetypes", function()
+    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, {})
+    table.sort(cfg.fakelsp.filetypes)
+    table.sort(cfg.pylsp.filetypes)
+    table.sort(cfg.pyright.filetypes)
+    table.sort(cfg.tsserver.filetypes)
+    assert.same({ "javascript", "python", "typescript" }, cfg.fakelsp.filetypes)
+    assert.same({ "python" }, cfg.pylsp.filetypes)
+    assert.same({ "python" }, cfg.pyright.filetypes)
+    assert.same({ "javascript", "typescript" }, cfg.tsserver.filetypes)
+  end)
+
+  it("sets filetypes based on preferred_servers option", function()
+    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, {
+      preferred_servers = {
+        python = { "pyright" },
+        typescript = "tsserver",
+      },
+    })
+    table.sort(cfg.fakelsp.filetypes)
+    table.sort(cfg.pyright.filetypes)
+    table.sort(cfg.tsserver.filetypes)
+    assert.is_nil(cfg.pylsp)
+    assert.same({ "javascript" }, cfg.fakelsp.filetypes)
+    assert.same({ "python" }, cfg.pyright.filetypes)
+    assert.same({ "javascript", "typescript" }, cfg.tsserver.filetypes)
+  end)
+end)


### PR DESCRIPTION
Resolves #17

What do you think @zoriya?

One downside I see is that for example to set preference for `typescript` to `tsserver`, one would need to repeat the preferrence many times given that `typescript` defines many filetypes: `{ 'javascript', 'javascriptreact', 'javascript.jsx', 'typescript', 'typescriptreact', 'typescript.tsx', }`. :thinking: 
