### PR TITLE
fix bazelrc_lsp after rename

### DIFF
--- a/lua/lazy-lsp/servers.lua
+++ b/lua/lazy-lsp/servers.lua
@@ -18,7 +18,7 @@ return {
   ballerina = "",
   basedpyright = "basedpyright",
   bashls = "nodePackages.bash-language-server",
-  ["bazelrc-lsp"] = "",
+  bazelrc_lsp = "",
   beancount = "beancount-language-server",
   bicep = "",
   biome = "",


### PR DESCRIPTION
This change corrects the `bazelrc-lsp` name with the one expected in `nvim-lspconfig` as of this commit: https://github.com/neovim/nvim-lspconfig/commit/0274356c5f3f913e866de390c43e02ed0b32de00 

Was getting a startup error: [lspconfig] Cannot access configuration for bazelrc-lsp. Ensure this server is listed in `server_configurations.md` or added as a custom server.

Leading to:
```
Failed to run `config` for lazy-lsp.nvim
                                                                                                                                                                              
...l/share/nvim/lazy/lazy-lsp.nvim/lua/lazy-lsp/helpers.lua:73: attempt to index field 'document_config' (a nil value)                                                        
                                                                                                                                                                              
# stacktrace:                                                                                                                                                                 
  - /lazy-lsp.nvim/lua/lazy-lsp/helpers.lua:73 _in_ **build_filetype_to_servers_index**                                                                                       
  - /lazy-lsp.nvim/lua/lazy-lsp/helpers.lua:109 _in_ **enabled_filetypes_to_servers**                                                                                         
  - /lazy-lsp.nvim/lua/lazy-lsp/helpers.lua:127 _in_ **server_configs**                                                                                                       
  - /lazy-lsp.nvim/lua/lazy-lsp/init.lua:7 _in_ **setup**                                                                                                                     
  - ~/.config/nvim/lua/kickstart/plugins/lspconfig.lua:29 _in_ **config**                                                                                                     
  - ~/.config/nvim/lua/lazy-plugins.lua:6                                                                                                                                     
  - ~/.config/nvim/init.lua:13 
```