### PR TITLE
fix(init, helpers): fix lsp attachment issue

### DIFF
--- a/lua/lazy-lsp/init.lua
+++ b/lua/lazy-lsp/init.lua
@@ -40,9 +40,19 @@ local function setup_with_vim_lsp_config(opts)
   for server, config in pairs(helpers.vim_lsp_server_configs(vim.lsp.config, servers, opts, overrides)) do
     assert(config.filetypes, "server " .. server .. " does not provide filetypes and is not omitted")
 
-    -- For Neovim 0.11+
-    vim.lsp.config(server, config)
-    vim.lsp.enable(server)
+    local lsp_group = vim.api.nvim_create_augroup("lazy_lsp_setup_vim_lsp_config", { clear = false })
+    local autocmd_id
+    autocmd_id = vim.api.nvim_create_autocmd("FileType", {
+      pattern = config.filetypes,
+      callback = function(opt)
+        vim.api.nvim_del_autocmd(autocmd_id)
+
+        vim.lsp.config(server, config)
+        vim.lsp.enable(server)
+      end,
+      group = lsp_group,
+      desc = string.format("Lazily setup %s lsp server with vim.lsp.config", server),
+    })
   end
 end
 

--- a/tests/helpers_spec.lua
+++ b/tests/helpers_spec.lua
@@ -361,7 +361,7 @@ describe("server_configs", function()
   end)
 
   it("augments commands with nix-shell", function()
-    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, {}, fake_overrides)
+    local cfg = helpers.server_configs(fake_lspconfig, fake_servers, { prefer_local = false }, fake_overrides)
     assert.same({ "nix-shell", "-p", "fakelsp-package", "--run", "'fakelsp-binary'" }, make_config(cfg.fakelsp).cmd)
     assert.same(
       { "nix-shell", "-p", "python39Packages.python-lsp-server", "--run", "'pylsp'" },


### PR DESCRIPTION
This fixes the issue where every LSP client was being attached regardless of the specified filetypes when prefer_local was set to true. Now, only the LSP clients matching the filetype will be attached.