### PR TITLE
call vim.lsp.start after vim.lsp.enable to start lazily enabled server

### DIFF
--- a/lua/lazy-lsp/init.lua
+++ b/lua/lazy-lsp/init.lua
@@ -85,6 +85,7 @@ local function setup_with_vim_lsp_config(opts)
 
         vim.lsp.config(server, config)
         vim.lsp.enable(server)
+        vim.lsp.start(config)
       end,
       group = lsp_group,
       desc = string.format("Lazily setup %s lsp server with vim.lsp.config", server),


### PR DESCRIPTION
Currently, with the new `use_vim_lsp_config` workflow, `vim.lsp.enable` is called lazily by an autocommand the first time a file of the appropriate type is opened. However, this does not start the server itself. This patch adds the start call to the autocommand.