### PR TITLE
Rename "elixir_ls" to "elixir-ls"

### DIFF
--- a/lua/lazy-lsp/servers.lua
+++ b/lua/lazy-lsp/servers.lua
@@ -101,7 +101,7 @@ return {
   ecsact = "",
   efm = "efm-langserver",
   elixirls = {
-    "elixir_ls",
+    "elixir-ls",
     "beamPackages.hex"
   },
   elmls = "elmPackages.elm-language-server",


### PR DESCRIPTION
The nix package `elixir_ls` has recently been renamed to `elixir-ls`, and now throws an error when you attempt to evaluate the format:

```bash
❯ nix run nixpkgs#elixir_ls
error:
       … while evaluating a branch condition
         at «github:nixos/nixpkgs/846ad5c»/pkgs/top-level/aliases.nix:27:5:
           26|     alias:
           27|     if alias.recurseForDerivations or false then
             |     ^
           28|       lib.removeAttrs alias [ "recurseForDerivations" ]

       … while calling the 'throw' builtin
         at «github:nixos/nixpkgs/846ad5c»/pkgs/top-level/aliases.nix:634:15:
          633|   elementsd-simplicity = throw "'elementsd-simplicity' has been removed due to lack of maintenance, consider using 'elementsd' instead"; # Added 2025-06-04
          634|   elixir_ls = throw "'elixir_ls' has been renamed to/replaced by 'elixir-ls'"; # Converted to throw 2025-10-27
             |               ^
          635|   elm-github-install = throw "'elm-github-install' has been removed as it is abandoned upstream and only supports Elm 0.18.0"; # Added 2025-08-25

       error: 'elixir_ls' has been renamed to/replaced by 'elixir-ls'
```
