### PR TITLE
fix: require("lspconfig") deprecation

### DIFF
--- a/lua/lazy-lsp/init.lua
+++ b/lua/lazy-lsp/init.lua
@@ -1,7 +1,7 @@
 local helpers = require("lazy-lsp.helpers")
 
 local function setup_with_lspconfig(opts)
-  local lspconfig = require("lspconfig")
+  local lspconfig = vim.lsp.config
   local servers = require("lazy-lsp.servers")
   local overrides = require("lazy-lsp.overrides")
   for server, config in pairs(helpers.server_configs(lspconfig, servers, opts, overrides)) do


### PR DESCRIPTION
I found out that `require("lspconfig")` would be deprecated soon in favor of `vim.lsp.config`